### PR TITLE
Hybrid inference with multiple compute devices

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,14 +3,17 @@
     "editor.rulers": [120],
     "pylint.args": [
         "--max-line-length=120",
-        "--disable=missing-module-docstring,missing-function-docstring",
+        "--disable=missing-module-docstring,missing-function-docstring,missing-class-docstring",
     ],
     "cSpell.words": [
         "cabextract",
+        "gelu",
+        "keepdim",
         "MLFLOW",
         "MNLI",
         "MRPC",
         "ndarray",
+        "pooler",
         "PYTHONPATH",
         "QNLI",
         "SNLI",

--- a/nl_dpe/dpe.py
+++ b/nl_dpe/dpe.py
@@ -19,10 +19,10 @@ from jaxtyping import Float
 __all__ = ["attention_head_index", "enabled", "call"]
 
 
-_BERT_LAYER_INDEX: int = 1
+_BERT_LAYER_INDEX: int = -1
 """1-based layer index (1, 2, 3, 4) or -1 to disable DPE call."""
 
-_ATTENTION_HEAD_INDEX: int = 2
+_ATTENTION_HEAD_INDEX: int = -1
 """1-based attention head index [1, 2, ..., 12] inclusive or -1 to disable DPE call."""
 
 
@@ -43,11 +43,11 @@ def enabled(bert_layer_index: int) -> bool:
 
 
 def call(
-        attention_input: Float[torch.Tensor, "batch sequence input_sz"]
+        attention_input: Float[torch.Tensor, "batch seq head_in_dim"]
 ) -> tuple[
-        Float[torch.Tensor, "batch sequence output_sz"],
-        Float[torch.Tensor, "batch sequence output_sz"],
-        Float[torch.Tensor, "batch sequence output_sz"]
+        Float[torch.Tensor, "batch seq head_out_dim"],
+        Float[torch.Tensor, "batch seq head_out_dim"],
+        Float[torch.Tensor, "batch seq head_out_dim"]
 ]:
     """Call the DPE engine that computes query, key and value matrices for dot-product attention for one attention head.
 
@@ -60,14 +60,14 @@ def call(
     
     Returns:
         A tuple of three tensors - query, key and value. For models in this repository, this will be something like
-        (32, 64, 312). Output dimension is determined by the weight tensors previously exported.
+        (32, 64, 26). Output dimension is determined by the weight tensors previously exported.
     """
 
     # Just for example, placeholder implementation returns random tensors.
     output_dim: int = 26
     output_shape: torch.Size = torch.Size((attention_input.shape[0], attention_input.shape[1], output_dim))
 
-    def _random_tensor() -> Float[torch.Tensor, "batch sequence output_sz"]:
+    def _random_tensor() -> Float[torch.Tensor, "batch seq head_out_dim"]:
         return torch.randn(output_shape, dtype=attention_input.dtype, device=attention_input.device)
 
     return (_random_tensor(), _random_tensor(), _random_tensor())

--- a/nl_dpe/dpe.py
+++ b/nl_dpe/dpe.py
@@ -1,0 +1,73 @@
+###
+# Copyright (2025) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+import torch
+from jaxtyping import Float
+
+__all__ = ["attention_head_index", "enabled", "call"]
+
+
+_BERT_LAYER_INDEX: int = 1
+"""1-based layer index (1, 2, 3, 4) or -1 to disable DPE call."""
+
+_ATTENTION_HEAD_INDEX: int = 2
+"""1-based attention head index [1, 2, ..., 12] inclusive or -1 to disable DPE call."""
+
+
+def attention_head_index() -> int:
+    return _ATTENTION_HEAD_INDEX
+
+
+def enabled(bert_layer_index: int) -> bool:
+    """Check if DPE is enabled.
+
+    Args:
+        bert_layer_index: Index of the BERT layer for which we check if DPE is enabled.
+
+    Returns:
+        True if DPE is enabled, False otherwise.
+    """
+    return bert_layer_index == _BERT_LAYER_INDEX and _ATTENTION_HEAD_INDEX >= 1
+
+
+def call(
+        attention_input: Float[torch.Tensor, "batch sequence input_sz"]
+) -> tuple[
+        Float[torch.Tensor, "batch sequence output_sz"],
+        Float[torch.Tensor, "batch sequence output_sz"],
+        Float[torch.Tensor, "batch sequence output_sz"]
+]:
+    """Call the DPE engine that computes query, key and value matrices for dot-product attention for one attention head.
+
+    Args:
+        attention_input: Rank-3 tensor containing input for attention module. First dimension is batch dimension,
+            its size could be 32. Second dimension is length of the input sequence dimension, its size could be 64.
+            Last dimension is input size dimension. Typically, that's the same as hidden size, but here that will be
+            hidden_size // num_attention_heads. It could be 26 (12 (num_attention_heads) * 26 (input attention size) = 
+            312 (hidden size)).
+    
+    Returns:
+        A tuple of three tensors - query, key and value. For models in this repository, this will be something like
+        (32, 64, 312). Output dimension is determined by the weight tensors previously exported.
+    """
+
+    # Just for example, placeholder implementation returns random tensors.
+    output_dim: int = 26
+    output_shape: torch.Size = torch.Size((attention_input.shape[0], attention_input.shape[1], output_dim))
+
+    def _random_tensor() -> Float[torch.Tensor, "batch sequence output_sz"]:
+        return torch.randn(output_shape, dtype=attention_input.dtype, device=attention_input.device)
+
+    return (_random_tensor(), _random_tensor(), _random_tensor())

--- a/nl_dpe/dpe.py
+++ b/nl_dpe/dpe.py
@@ -43,11 +43,11 @@ def enabled(bert_layer_index: int) -> bool:
 
 
 def call(
-        attention_input: Float[torch.Tensor, "batch seq head_in_dim"]
+    attention_input: Float[torch.Tensor, "batch seq head_in_dim"],
 ) -> tuple[
-        Float[torch.Tensor, "batch seq head_out_dim"],
-        Float[torch.Tensor, "batch seq head_out_dim"],
-        Float[torch.Tensor, "batch seq head_out_dim"]
+    Float[torch.Tensor, "batch seq head_out_dim"],  # Query
+    Float[torch.Tensor, "batch seq head_out_dim"],  # Key
+    Float[torch.Tensor, "batch seq head_out_dim"],  # Value
 ]:
     """Call the DPE engine that computes query, key and value matrices for dot-product attention for one attention head.
 
@@ -55,19 +55,31 @@ def call(
         attention_input: Rank-3 tensor containing input for attention module. First dimension is batch dimension,
             its size could be 32. Second dimension is length of the input sequence dimension, its size could be 64.
             Last dimension is input size dimension. Typically, that's the same as hidden size, but here that will be
-            hidden_size // num_attention_heads. It could be 26 (12 (num_attention_heads) * 26 (input attention size) = 
+            hidden_size // num_attention_heads. It could be 26 (12 (num_attention_heads) * 26 (input attention size) =
             312 (hidden size)).
-    
+
     Returns:
         A tuple of three tensors - query, key and value. For models in this repository, this will be something like
         (32, 64, 26). Output dimension is determined by the weight tensors previously exported.
     """
 
-    # Just for example, placeholder implementation returns random tensors.
-    output_dim: int = 26
-    output_shape: torch.Size = torch.Size((attention_input.shape[0], attention_input.shape[1], output_dim))
+    # Just for example, placeholder implementation. Most likely, the input PyTorch tensor needs to be converted to
+    # a numpy array.
+    head_out_dim: int = 26  # This is defined by the three matrices (W_k, W_q, W_v) that were previously exported.
 
-    def _random_tensor() -> Float[torch.Tensor, "batch seq head_out_dim"]:
-        return torch.randn(output_shape, dtype=attention_input.dtype, device=attention_input.device)
+    def _random_weight_tensor() -> Float[torch.Tensor, "head_in_dim head_out_dim"]:
+        shape: torch.Size = torch.Size((attention_input.shape[-1], head_out_dim))
+        return torch.randn(shape, dtype=attention_input.dtype, device=attention_input.device)
 
-    return (_random_tensor(), _random_tensor(), _random_tensor())
+    # The following three matrices have supposedly been programmed onto the external compute device.
+    w_query: Float[torch.Tensor, "head_out_dim head_in_dim"] = _random_weight_tensor()
+    w_key: Float[torch.Tensor, "head_out_dim head_in_dim"] = _random_weight_tensor()
+    w_value: Float[torch.Tensor, "head_out_dim head_in_dim"] = _random_weight_tensor()
+
+    # This simulates matrix multiplication on an external compute device (b - batch, s - seq, i - head_in_dim,
+    # o - head_out_dim).
+    query: Float[torch.Tensor, "batch seq head_out_dim"] = torch.einsum("bsi, io -> bso", attention_input, w_query)
+    key: Float[torch.Tensor, "batch seq head_out_dim"] = torch.einsum("bsi, io -> bso", attention_input, w_key)
+    value: Float[torch.Tensor, "batch seq head_out_dim"] = torch.einsum("bsi, io -> bso", attention_input, w_value)
+
+    return (query, key, value)

--- a/nl_dpe/evaluate.py
+++ b/nl_dpe/evaluate.py
@@ -32,6 +32,7 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
+from jaxtyping import Float, Int, Num
 from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import f1_score, matthews_corrcoef
 from torch.nn import CrossEntropyLoss, MSELoss
@@ -397,8 +398,16 @@ def do_eval(
 ) -> Dict:
     eval_loss: float = 0
     nb_eval_steps: int = 0
-    preds = []
+    preds: list[np.ndarray] = []
 
+    batch_: tuple[
+        Int[torch.Tensor, "batch seq"],  # input_ids
+        Int[torch.Tensor, "batch seq"],  # input_mask
+        Int[torch.Tensor, "batch seq"],  # segment_ids
+        Int[torch.Tensor, " batch"],     # label_ids
+        Int[torch.Tensor, " batch"]      # seq_lengths
+    ]
+    logits: Float[torch.Tensor, "batch class"]
     for batch_ in tqdm(eval_dataloader, desc="Evaluating"):
         batch_ = tuple(t.to(device) for t in batch_)
         with torch.no_grad():
@@ -436,7 +445,11 @@ def do_eval(
     return result
 
 
-def compute_metrics(task_name: str, preds, labels) -> Dict:
+def compute_metrics(
+        task_name: str, 
+        preds: Num[np.ndarray, " dim"], 
+        labels: Num[np.ndarray, " dim"]
+) -> Dict:
     assert len(preds) == len(labels)
 
     def simple_accuracy(preds, labels) -> float:

--- a/nl_dpe/evaluate.py
+++ b/nl_dpe/evaluate.py
@@ -372,6 +372,7 @@ def evaluate(task_name: str, model_uri: str, data_dir: str, eval_batch_size: int
 
     model = TinyBertForSequenceClassification.from_pretrained(model_path, num_labels=task.num_labels())
     model.to(device)
+    print(f"Task name: {task_name}, model class: {type(model)}")
 
     logger.info("***** Running evaluation *****")
     logger.info("  Num examples = %d", len(eval_examples))

--- a/poetry.lock
+++ b/poetry.lock
@@ -496,6 +496,24 @@ files = [
 ]
 
 [[package]]
+name = "jaxtyping"
+version = "0.3.2"
+description = "Type annotations and runtime checking for shape and dtype of JAX/NumPy/PyTorch/etc. arrays."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jaxtyping-0.3.2-py3-none-any.whl", hash = "sha256:6a020fd276226ddb5ac4f5725323843dd65e3c7e85c64fd62431e5f738c74e04"},
+    {file = "jaxtyping-0.3.2.tar.gz", hash = "sha256:f30483fac4b42e915db8ad2414a85c3b63284aa7d3c100b96b59f755cf4a86ad"},
+]
+
+[package.dependencies]
+wadler-lindig = ">=0.1.3"
+
+[package.extras]
+docs = ["hippogriffe (==0.2.0)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.0)", "mkdocs-material (==9.6.7)", "mkdocstrings[python] (==0.28.3)", "pymdown-extensions (==10.14.3)"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -1991,6 +2009,22 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [[package]]
+name = "wadler-lindig"
+version = "0.1.6"
+description = "A Wadler–Lindig pretty-printer for Python."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "wadler_lindig-0.1.6-py3-none-any.whl", hash = "sha256:d707f63994c7d3e1e125e7fb7e196f4adb6f80f4a11beb955c6da937754026a3"},
+    {file = "wadler_lindig-0.1.6.tar.gz", hash = "sha256:8b6adad9718291a7d82fb088a596b93659ce2346321ca76819810affbc66102b"},
+]
+
+[package.extras]
+dev = ["numpy", "pre-commit", "pytest"]
+docs = ["hippogriffe (==0.1.0)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.0)", "mkdocs-material (==9.6.7)", "mkdocstrings[python] (==0.28.3)", "pymdown-extensions (==10.14.3)"]
+
+[[package]]
 name = "wrapt"
 version = "1.17.2"
 description = "Module for decorators, wrappers and monkey patching."
@@ -2102,4 +2136,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<=3.12"
-content-hash = "6414edbf0e4b8946526f485db86f1409307fb3e856278eb229c860b3ce6c1c88"
+content-hash = "da6967438707d7c4f4ebdc4ff3e79f918fc67031fddef075d21f281b0cc749d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ numpy = ">=2.0.0"
 scipy = ">=1.14.0"
 scikit-learn = ">=1.5.0"
 mlflow-skinny = ">=2.14.0"
+jaxtyping = ">=0.3.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -30,6 +31,9 @@ line-length = 120
 
 [tool.ruff.lint]
 extend-select = ["I"]      # Enable the isort rules.
+ignore = [
+    "F722"   # jaxtyping fix (https://docs.kidger.site/jaxtyping/faq/#flake8-or-ruff-are-throwing-an-error) 
+]
 
 
 [build-system]

--- a/transformer/modeling.py
+++ b/transformer/modeling.py
@@ -466,7 +466,7 @@ class BertSelfAttention(nn.Module):
         mixed_value_layer: Float[torch.Tensor, "batch sequence hidden_size"] = self.value(attention_input)
 
         if dpe.enabled(self.bert_layer_index):
-            dpe_query, dpe_key, dpe_value = dpe.call(mixed_query_layer)
+            dpe_query, dpe_key, dpe_value = dpe.call(attention_input)
             start_idx: int = (dpe.attention_head_index() - 1) * self.attention_head_size
             end_idx: int = start_idx + self.attention_head_size
 

--- a/transformer/modeling.py
+++ b/transformer/modeling.py
@@ -30,6 +30,7 @@ import torch
 from jaxtyping import Float, Int
 from torch import Tensor, nn
 from torch.nn import CrossEntropyLoss
+
 import nl_dpe.dpe as dpe
 
 from .file_utils import CONFIG_NAME, WEIGHTS_NAME
@@ -72,13 +73,13 @@ def load_tf_weights_in_bert(model, tf_checkpoint_path):
         )
         raise
     tf_path = os.path.abspath(tf_checkpoint_path)
-    print("Converting TensorFlow checkpoint from {}".format(tf_path))
+    print(f"Converting TensorFlow checkpoint from {tf_path}.")
     # Load weights from TF model
     init_vars = tf.train.list_variables(tf_path)
     names = []
     arrays = []
     for name, shape in init_vars:
-        print("Loading TF weight {} with shape {}".format(name, shape))
+        print(f"Loading TF weight {name} with shape {shape}.")
         array = tf.train.load_variable(tf_path, name)
         names.append(name)
         arrays.append(array)
@@ -88,7 +89,7 @@ def load_tf_weights_in_bert(model, tf_checkpoint_path):
         # adam_v and adam_m are variables used in AdamWeightDecayOptimizer to calculated m and v
         # which are not required for using pretrained model
         if any(n in ["adam_v", "adam_m", "global_step"] for n in name):
-            print("Skipping {}".format("/".join(name)))
+            print("Skipping:", "/".join(name))
             continue
         pointer = model
         for m_name in name:
@@ -102,7 +103,7 @@ def load_tf_weights_in_bert(model, tf_checkpoint_path):
                 try:
                     pointer = getattr(pointer, "bias")
                 except AttributeError:
-                    print("Skipping {}".format("/".join(name)))
+                    print("Skipping:", "/".join(name))
                     continue
             elif l[0] == "output_weights":
                 pointer = getattr(pointer, "weight")
@@ -112,7 +113,7 @@ def load_tf_weights_in_bert(model, tf_checkpoint_path):
                 try:
                     pointer = getattr(pointer, l[0])
                 except AttributeError:
-                    print("Skipping {}".format("/".join(name)))
+                    print("Skipping:", "/".join(name))
                     continue
             if len(l) >= 2:
                 num = int(l[1])
@@ -126,12 +127,12 @@ def load_tf_weights_in_bert(model, tf_checkpoint_path):
         except AssertionError as e:
             e.args += (pointer.shape, array.shape)
             raise
-        print("Initialize PyTorch weight {}".format(name))
+        print(f"Initialize PyTorch weight {namme}.")
         pointer.data = torch.from_numpy(array)
     return model
 
 
-def gelu(x):
+def gelu(x: Float[torch.Tensor, "..."]) -> Float[torch.Tensor, "..."]:
     """Implementation of the gelu activation function.
     For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
     0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3))))
@@ -157,9 +158,9 @@ except ImportError:
             self.bias = nn.Parameter(torch.zeros(hidden_size))
             self.variance_epsilon = eps
 
-        def forward(self, x: Tensor) -> Tensor:
-            u = x.mean(-1, keepdim=True)
-            s = (x - u).pow(2).mean(-1, keepdim=True)
+        def forward(self, x: Float[torch.Tensor, "batch seq model_dim"]) -> Float[torch.Tensor, "batch seq model_dim"]:
+            u: Float[torch.Tensor, "batch seq 1"] = x.mean(-1, keepdim=True)
+            s: Float[torch.Tensor, "batch seq 1"] = (x - u).pow(2).mean(-1, keepdim=True)
             x = (x - u) / torch.sqrt(s + self.variance_epsilon)
             return self.weight * x + self.bias
 
@@ -172,8 +173,8 @@ class HeadAttention(nn.Module):
         self.hidden_size = hidden_size
         if self.hidden_size % self.head_num != 0:
             raise ValueError(
-                "The hidden size (%d) is not a multiple of the number of attention "
-                "heads (%d)" % (self.hidden_size, self.head_num)
+                f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
+                f"heads ({self.head_num})."
             )
 
         self.attention_head_size = int(self.hidden_size / self.head_num)
@@ -275,7 +276,7 @@ class BertConfig(object):
                 layer in the Transformer encoder.
             hidden_act: The non-linear activation function (function or string) in the
                 encoder and pooler. If string, "gelu", "relu" and "swish" are supported.
-            hidden_dropout_prob: The dropout probabilitiy for all fully connected
+            hidden_dropout_prob: The dropout probability for all fully connected
                 layers in the embeddings, encoder, and pooler.
             attention_probs_dropout_prob: The dropout ratio for the attention
                 probabilities.
@@ -384,26 +385,30 @@ class BertEmbeddings(nn.Module):
         self.LayerNorm = BertLayerNorm(embedding_dim, eps=1e-12)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-    def forward(self, input_ids: Tensor, token_type_ids: Optional[Tensor] = None) -> Tensor:
-        # input_ids: [Batch, Length]
-        seq_length = input_ids.size(1)
-        position_ids = torch.arange(seq_length, dtype=torch.long, device=input_ids.device)
-        position_ids = position_ids.unsqueeze(0).expand_as(input_ids)
+    def forward(
+            self,
+            input_ids: Int[torch.Tensor, "batch seq"],
+            token_type_ids: Optional[Int[torch.Tensor, "batch seq"]] = None
+    ) -> Float[torch.Tensor, "batch seq model_dim"]:
+        seq_length: int = input_ids.size(1)
+        position_ids: Int[torch.Tensor, " seq"] = torch.arange(seq_length, dtype=torch.long, device=input_ids.device)
+        position_ids: Int[torch.Tensor, "batch seq"] = position_ids.unsqueeze(0).expand_as(input_ids)
         if token_type_ids is None:
             token_type_ids = torch.zeros_like(input_ids)
 
-        words_embeddings = self.word_embeddings(input_ids)
-        position_embeddings = self.position_embeddings(position_ids)
-        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+        words_embeddings: Float[torch.Tensor, "batch seq model_dim"] = self.word_embeddings(input_ids)
+        position_embeddings: Float[torch.Tensor, "batch seq model_dim"] = self.position_embeddings(position_ids)
+        token_type_embeddings: Float[torch.Tensor, "batch seq model_dim"] = self.token_type_embeddings(token_type_ids)
 
-        embeddings = words_embeddings + position_embeddings + token_type_embeddings
+        embeddings: Float[torch.Tensor, "batch seq model_dim"] = \
+            words_embeddings + position_embeddings + token_type_embeddings
         embeddings = self.LayerNorm(embeddings)
-        embeddings = self.dropout(embeddings)  # [Batch, Length, EmdSz]
+        embeddings = self.dropout(embeddings)
 
         if self.dim_reduction_layer is not None:
             embeddings = self.dim_reduction_layer(embeddings)
 
-        return embeddings  # [Batch, Length, HiddenSize]
+        return embeddings
 
 
 class BertSelfAttention(nn.Module):
@@ -431,23 +436,23 @@ class BertSelfAttention(nn.Module):
         self.bert_layer_index = bert_layer_index
 
     def transpose_for_scores(
-            self, x: Float[torch.Tensor, "batch sequence hidden_size"]
-    ) -> Float[torch.Tensor, "batch num_heads sequence head_size"]:
+            self, x: Float[torch.Tensor, "batch seq model_dim"]
+    ) -> Float[torch.Tensor, "batch head seq model_dim"]:
         new_x_shape: torch.Size = cast(torch.Size, x.size()[:-1] + (self.num_attention_heads, self.attention_head_size))
         x = x.view(*new_x_shape)
         return x.permute(0, 2, 1, 3)
 
     def forward(
             self,
-            hidden_states: Float[torch.Tensor, "batch sequence hidden_size"],
-            attention_mask: Float[torch.Tensor, "batch 1 1 sequence"],
+            hidden_states: Float[torch.Tensor, "batch seq model_dim"],
+            attention_mask: Float[torch.Tensor, "batch 1 1 seq"],
             output_att: bool = False
     ) -> Tuple[
-        Float[torch.Tensor, "batch sequence hidden_size"],
-        Float[torch.Tensor, "batch num_heads sequence sequence"]
+            Float[torch.Tensor, "batch seq model_dim"],
+            Float[torch.Tensor, "batch head seq seq"]
     ]:
-        # attention_size could be different from hidden_size.
-        attention_input: Float[torch.Tensor, "batch sequence attention_size"]
+        # head_in_dim could be different from model_dim.
+        attention_input: Float[torch.Tensor, "batch seq head_in_dim"]
         # hidden_states: [Batch, SeqLen, HiddenSz] attention_mask: [Batch, 1, 1, SeqLen]
         if self.arch == BertArchitecture.AVERAGE_HIDDEN_STATES:
             hidden_states = hidden_states.reshape(
@@ -461,9 +466,9 @@ class BertSelfAttention(nn.Module):
             attention_input = hidden_states
 
         # These linear layers will bring input dimension back to hidden size if input was reduced above.
-        mixed_query_layer: Float[torch.Tensor, "batch sequence hidden_size"] = self.query(attention_input)
-        mixed_key_layer: Float[torch.Tensor, "batch sequence hidden_size"] = self.key(attention_input)
-        mixed_value_layer: Float[torch.Tensor, "batch sequence hidden_size"] = self.value(attention_input)
+        mixed_query_layer: Float[torch.Tensor, "batch seq model_dim"] = self.query(attention_input)
+        mixed_key_layer: Float[torch.Tensor, "batch seq model_dim"] = self.key(attention_input)
+        mixed_value_layer: Float[torch.Tensor, "batch seq model_dim"] = self.value(attention_input)
 
         if dpe.enabled(self.bert_layer_index):
             dpe_query, dpe_key, dpe_value = dpe.call(attention_input)
@@ -474,18 +479,18 @@ class BertSelfAttention(nn.Module):
             mixed_key_layer[: , :, start_idx:end_idx] = dpe_key
             mixed_value_layer[: , :, start_idx:end_idx] = dpe_value
 
-        query_layer: Float[torch.Tensor, "batch num_heads sequence head_size"] = self.transpose_for_scores(
+        query_layer: Float[torch.Tensor, "batch head seq head_out_dim"] = self.transpose_for_scores(
             mixed_query_layer
         )
-        key_layer: Float[torch.Tensor, "batch num_heads sequence head_size"] = self.transpose_for_scores(
+        key_layer: Float[torch.Tensor, "batch head seq head_out_dim"] = self.transpose_for_scores(
             mixed_key_layer
         )
-        value_layer: Float[torch.Tensor, "batch num_heads sequence head_size"] = self.transpose_for_scores(
+        value_layer: Float[torch.Tensor, "batch head seq head_out_dim"] = self.transpose_for_scores(
             mixed_value_layer
         )
 
         # Take the dot product between "query" and "key" to get the raw attention scores.
-        attention_scores: Float[torch.Tensor, "batch num_heads sequence sequence"] = torch.matmul(
+        attention_scores: Float[torch.Tensor, "batch head seq seq"] = torch.matmul(
             query_layer, key_layer.transpose(-1, -2)
         )
         attention_scores = attention_scores / math.sqrt(self.attention_head_size)
@@ -493,18 +498,18 @@ class BertSelfAttention(nn.Module):
         attention_scores = attention_scores + attention_mask  # [Batch, NumAttHeads, SeqLen, SeqLen]
 
         # Normalize the attention scores to probabilities.
-        attention_probs: Float[torch.Tensor, "batch num_heads sequence sequence"] = nn.Softmax(dim=-1)(attention_scores)
+        attention_probs: Float[torch.Tensor, "batch head seq seq"] = nn.Softmax(dim=-1)(attention_scores)
 
         # This is actually dropping out entire tokens to attend to, which might
         # seem a bit unusual, but is taken from the original Transformer paper.
         attention_probs = self.dropout(attention_probs)
 
-        context_layer: Float[torch.Tensor, "batch num_heads sequence head_size"] = torch.matmul(
+        context_layer: Float[torch.Tensor, "batch head seq head_out_dim"] = torch.matmul(
             attention_probs, value_layer
         )
         context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
         new_context_layer_shape: torch.Size = cast(torch.Size, context_layer.size()[:-2] + (self.all_head_size, ))
-        context_layer: Float[torch.Tensor, "batch sequence hidden_size"] = context_layer.view(*new_context_layer_shape)
+        context_layer: Float[torch.Tensor, "batch seq model_dim"] = context_layer.view(*new_context_layer_shape)
 
         return context_layer, attention_scores
 
@@ -514,25 +519,21 @@ class BertAttention(nn.Module):
         super(BertAttention, self).__init__()
 
         self.self = BertSelfAttention(config, bert_layer_index)
-        self.output = BertSelfOutput(config)  # Dense, DropOut,LayerNorm,AddSkipConnect
+        self.output = BertSelfOutput(config)
         self.bert_layer_index = bert_layer_index
 
     def forward(
             self,
-            input_tensor: Float[torch.Tensor, "batch sequence hidden_size"],
-            attention_mask: Float[torch.Tensor, "batch 1 1 sequence"]
+            input_tensor: Float[torch.Tensor, "batch seq model_dim"],
+            attention_mask: Float[torch.Tensor, "batch 1 1 seq"]
     ) -> Tuple[
-        Float[torch.Tensor, "batch sequence hidden_size"],
-        Float[torch.Tensor, "batch head_size sequence sequence"]
+            Float[torch.Tensor, "batch seq model_dim"],
+            Float[torch.Tensor, "batch head seq seq"]
     ]:
-        """
-        input_tensor: [Batch, SeqLen, HiddenSz]
-        attention_mask: [Batch, 1, 1, SeqLen]
-        """
-        # self_output: [Batch, SeqLen, HiddenSz], layer_att: [Batch, NumAttHeads, SeqLen, SeqLen]
-        self_output, layer_att = self.self(input_tensor, attention_mask)  # self-attention
-        # attention_output: [Batch, SeqLen, SeqLen]
-        attention_output: Tensor = self.output(self_output, input_tensor)  # self-output
+        self_output: Float[torch.Tensor, "batch seq model_dim"]
+        layer_att: Float[torch.Tensor, "batch head seq seq"]
+        self_output, layer_att = self.self(input_tensor, attention_mask)
+        attention_output: Float[torch.Tensor, "batch seq model_dim"] = self.output(self_output, input_tensor)
         return attention_output, layer_att
 
 
@@ -543,15 +544,15 @@ class BertSelfOutput(nn.Module):
         self.LayerNorm = BertLayerNorm(config.hidden_size, eps=1e-12)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-    def forward(self, hidden_states: Tensor, input_tensor: Tensor) -> Tensor:
-        """
-        hidden_states: [Batch, SeqLen, HiddenDim]
-        input_tensor: [Batch, SeqLen, HiddenDim]
-        """
+    def forward(
+            self,
+            hidden_states: Float[torch.Tensor, "batch seq model_dim"],
+            input_tensor: Float[torch.Tensor, "batch seq model_dim"]
+    ) -> Float[torch.Tensor, "batch seq model_dim"]:
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
-        return hidden_states  # [Batch, SeqLen, HiddenSz]
+        return hidden_states
 
 
 class BertIntermediate(nn.Module):
@@ -566,14 +567,16 @@ class BertIntermediate(nn.Module):
         else:
             self.intermediate_act_fn = config.hidden_act
 
-    def forward(self, hidden_states):
-        hidden_states = self.dense(hidden_states)
-        hidden_states = self.intermediate_act_fn(hidden_states)
-        return hidden_states
+    def forward(
+            self, hidden_states: Float[torch.Tensor, "batch seq model_dim"]
+    ) -> Float[torch.Tensor, "batch seq intermediate_dim"]:
+        y: Float[torch.Tensor, "batch seq intermediate_dim"] = self.dense(hidden_states)
+        y = self.intermediate_act_fn(y)
+        return y
 
 
 class BertOutput(nn.Module):
-    def __init__(self, config, intermediate_size=-1):
+    def __init__(self, config: BertConfig, intermediate_size: int = -1) -> None:
         super(BertOutput, self).__init__()
         if intermediate_size < 0:
             self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
@@ -582,11 +585,15 @@ class BertOutput(nn.Module):
         self.LayerNorm = BertLayerNorm(config.hidden_size, eps=1e-12)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-    def forward(self, hidden_states, input_tensor):
-        hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
-        hidden_states = self.LayerNorm(hidden_states + input_tensor)
-        return hidden_states
+    def forward(
+            self, 
+            hidden_states: Float[torch.Tensor, "batch seq intermediate_dim"], 
+            input_tensor: Float[torch.Tensor, "batch seq model_dim"]
+    ) -> Float[torch.Tensor, "batch seq model_dim"]:
+        y: Float[torch.Tensor, "batch seq model_dim"] = self.dense(hidden_states)
+        y = self.dropout(y)
+        y = self.LayerNorm(y + input_tensor)
+        return y
 
 
 class BertLayer(nn.Module):
@@ -599,20 +606,20 @@ class BertLayer(nn.Module):
 
     def forward(
             self,
-            hidden_states: Float[torch.Tensor, "batch sequence hidden_size"],
-            attention_mask: Float[torch.Tensor, "batch 1 1 sequence"]
+            hidden_states: Float[torch.Tensor, "batch seq model_dim"],
+            attention_mask: Float[torch.Tensor, "batch 1 1 seq"]
     ) -> Tuple[
-            Float[torch.Tensor, "batch sequence hidden_size"], # layer output
-            Float[torch.Tensor, "batch head_size sequence sequence"] # attention
+            Float[torch.Tensor, "batch seq model_dim"], # layer output
+            Float[torch.Tensor, "batch head seq seq"] # attention
     ]:
-        attention_output: Float[torch.Tensor, "batch sequence hidden_size"]
-        layer_att: Float[torch.Tensor, "batch head_size sequence sequence"]
+        attention_output: Float[torch.Tensor, "batch seq model_dim"]
+        layer_att: Float[torch.Tensor, "batch head seq seq"]
 
         attention_output, layer_att = self.attention(hidden_states, attention_mask)
-        intermediate_output: Float[torch.Tensor, "batch sequence intermediate_size"] = self.intermediate(
+        intermediate_output: Float[torch.Tensor, "batch seq intermediate_dim"] = self.intermediate(
             attention_output
         )
-        layer_output: Float[torch.Tensor, "batch sequence hidden_size"] = self.output(
+        layer_output: Float[torch.Tensor, "batch seq model_dim"] = self.output(
             intermediate_output, attention_output
         )
 
@@ -626,18 +633,18 @@ class BertEncoder(nn.Module):
 
     def forward(
             self,
-            hidden_states: Float[torch.Tensor, "batch sequence hidden_size"],
-            attention_mask: Float[torch.Tensor, "batch 1 1 sequence"]
+            hidden_states: Float[torch.Tensor, "batch seq model_dim"],
+            attention_mask: Float[torch.Tensor, "batch 1 1 seq"]
     ) -> Tuple[
-        list[Float[torch.Tensor, "batch sequence hidden_size"]], # hidden states
-        list[Float[torch.Tensor, "batch head_size sequence sequence"]] # attention outputs
+            list[Float[torch.Tensor, "batch seq model_dim"]], # hidden states
+            list[Float[torch.Tensor, "batch head seq seq"]] # attention outputs
     ]:
         """
         hidden_states: [Batch, Length, EmbDim]
         """
-        all_encoder_layers: list[Float[torch.Tensor, "batch sequence hidden_size"]] = []  # hidden states
-        all_encoder_atts: list[Float[torch.Tensor, "batch head_size sequence sequence"]] = []
-        layer_att: Float[torch.Tensor, "batch head_size sequence sequence"]
+        all_encoder_layers: list[Float[torch.Tensor, "batch seq model_dim"]] = []  # hidden states
+        all_encoder_atts: list[Float[torch.Tensor, "batch head seq seq"]] = []
+        layer_att: Float[torch.Tensor, "batch head seq seq"]
 
         layer_module: BertLayer
         for layer_module in self.layer:
@@ -650,16 +657,18 @@ class BertEncoder(nn.Module):
 
 
 class BertPooler(nn.Module):
-    def __init__(self, config, recurs=None):
+    def __init__(self, config: BertConfig, recurs=None) -> None:
         super(BertPooler, self).__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
         self.activation = nn.Tanh()
         self.config = config
 
-    def forward(self, hidden_states):
+    def forward(
+            self, hidden_states: list[Float[torch.Tensor, "batch seq model_dim"]]
+    ) -> Float[torch.Tensor, "batch model_dim"]:
         # We "pool" the model by simply taking the hidden state corresponding
         # to the first token. "-1" refers to last layer
-        pooled_output = hidden_states[-1][:, 0]
+        pooled_output: Float[torch.Tensor, "batch model_dim"]= hidden_states[-1][:, 0]
 
         pooled_output = self.dense(pooled_output)
         pooled_output = self.activation(pooled_output)
@@ -736,18 +745,17 @@ class BertPreTrainingHeads(nn.Module):
 
 class BertPreTrainedModel(nn.Module):
     """An abstract class to handle weights initialization and
-    a simple interface for dowloading and loading pretrained models.
+    a simple interface for downloading and loading pretrained models.
     """
 
     def __init__(self, config: BertConfig, *inputs, **kwargs) -> None:
         super(BertPreTrainedModel, self).__init__()
         if not isinstance(config, BertConfig):
+            cls_name: str = self.__class__.__name__
             raise ValueError(
-                "Parameter config in `{}(config)` should be an instance of class `BertConfig`. "
+                f"Parameter config in `{cls_name}(config)` should be an instance of class `BertConfig`. "
                 "To create a model from a Google pretrained model use "
-                "`model = {}.from_pretrained(PRETRAINED_MODEL_NAME)`".format(
-                    self.__class__.__name__, self.__class__.__name__
-                )
+                f"`model = {cls_name}.from_pretrained(PRETRAINED_MODEL_NAME)`"
             )
         self.config = config
 
@@ -802,7 +810,8 @@ class BertPreTrainedModel(nn.Module):
                     . `model.chkpt` a TensorFlow checkpoint
             from_tf: should we load the weights from a locally saved TensorFlow checkpoint
             cache_dir: an optional path to a folder in which the pre-trained models will be cached.
-            state_dict: an optional state dictionnary (collections.OrderedDict object) to use instead of Google pre-trained models
+            state_dict: an optional state dictionary (collections.OrderedDict object) to use instead of 
+                        Google pre-trained models
             *inputs, **kwargs: additional input for the specific Bert class
                 (ex: num_labels for BertForSequenceClassification)
         """
@@ -915,10 +924,11 @@ class BertModel(BertPreTrainedModel):
             selected in [0, 1]. It's a mask to be used if the input sequence length is smaller than the max
             input sequence length in the current batch. It's the mask that we typically use for attention when
             a batch has varying length sentences.
-        `output_all_encoded_layers`: boolean which controls the content of the `encoded_layers` output as described below. Default: `True`.
+        `output_all_encoded_layers`: boolean which controls the content of the `encoded_layers` output as described 
+            below. Default: `True`.
 
     Outputs: Tuple of (encoded_layers, pooled_output)
-        `encoded_layers`: controled by `output_all_encoded_layers` argument:
+        `encoded_layers`: controlled by `output_all_encoded_layers` argument:
             - `output_all_encoded_layers=True`: outputs a list of the full sequences of encoded-hidden-states at the end
                 of each attention block (i.e. 12 full sequences for BERT-base, 24 for BERT-large), each
                 encoded-hidden-state is a torch.FloatTensor of size [batch_size, sequence_length, hidden_size],
@@ -952,14 +962,14 @@ class BertModel(BertPreTrainedModel):
 
     def forward(
         self,
-        input_ids: Int[torch.Tensor, "batch sequence"],
-        token_type_ids: Optional[Int[torch.Tensor, "batch sequence"]] = None,
-        attention_mask: Optional[Int[torch.Tensor, "batch sequence"]] = None,
+        input_ids: Int[torch.Tensor, "batch seq"],
+        token_type_ids: Optional[Int[torch.Tensor, "batch seq"]] = None,
+        attention_mask: Optional[Int[torch.Tensor, "batch seq"]] = None,
         output_all_encoded_layers: bool = True,
         output_att: bool = True,
     ) -> Tuple[
-        torch.Tensor, 
-        torch.Tensor, 
+        torch.Tensor,
+        torch.Tensor,
         torch.Tensor
     ]:
         # input_ids, token_type_ids, attention_mask: [Batch, Length]
@@ -973,7 +983,7 @@ class BertModel(BertPreTrainedModel):
         # So we can broadcast to [batch_size, num_heads, from_seq_length, to_seq_length]
         # this attention mask is more simple than the triangular masking of causal attention
         # used in OpenAI GPT, we just need to prepare the broadcast dimension here.
-        extended_attention_mask: Float[torch.Tensor, "batch 1 1 sequence"] = attention_mask.unsqueeze(1).unsqueeze(2)
+        extended_attention_mask: Float[torch.Tensor, "batch 1 1 seq"] = attention_mask.unsqueeze(1).unsqueeze(2)
 
         # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
         # masked positions, this operation will create a tensor which is 0.0 for
@@ -983,11 +993,13 @@ class BertModel(BertPreTrainedModel):
         extended_attention_mask = extended_attention_mask.to(dtype=next(self.parameters()).dtype)  # fp16 compatibility
         extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
 
-        # embedding_output: [Batch, Length, EmbDim]
-        embedding_output: Float[torch.Tensor, "batch sequence hidden_size"] = self.embeddings(input_ids, token_type_ids)  # inputs [Batch, Length]
+        embedding_output: Float[torch.Tensor, "batch seq model_dim"] = self.embeddings(input_ids, token_type_ids)
+
+        encoded_layers: list[Float[torch.Tensor, "batch seq model_dim"]]  # hidden states
+        layer_atts: list[Float[torch.Tensor, "batch head seq seq"]]  # attention outputs
         encoded_layers, layer_atts = self.encoder(embedding_output, extended_attention_mask)
 
-        pooled_output = self.pooler(encoded_layers)
+        pooled_output: Float[torch.Tensor, "batch model_dim"] = self.pooler(encoded_layers)
         if not output_all_encoded_layers:
             encoded_layers = encoded_layers[-1]
 
@@ -1017,9 +1029,9 @@ class BertForPreTraining(BertPreTrainedModel):
             selected in [0, 1]. It's a mask to be used if the input sequence length is smaller than the max
             input sequence length in the current batch. It's the mask that we typically use for attention when
             a batch has varying length sentences.
-        `masked_lm_labels`: optional masked language modeling labels: torch.LongTensor of shape [batch_size, sequence_length]
-            with indices selected in [-1, 0, ..., vocab_size]. All labels set to -1 are ignored (masked), the loss
-            is only computed for the labels set in [0, ..., vocab_size]
+        `masked_lm_labels`: optional masked language modeling labels: torch.LongTensor of shape 
+            [batch_size, sequence_length] with indices selected in [-1, 0, ..., vocab_size]. All labels set to -1 are 
+            ignored (masked), the loss is only computed for the labels set in [0, ..., vocab_size]
         `next_sentence_label`: optional next sentence classification loss: torch.LongTensor of shape [batch_size]
             with indices selected in [0, 1].
             0 => next sentence is the continuation, 1 => next sentence is a random sentence.
@@ -1096,7 +1108,7 @@ class TinyBertForPreTraining(BertPreTrainedModel):
     ) -> Tuple[List[Tensor], List[Tensor]]:
         # input_ids, token_type_ids, attention_mask: [Batch, Length]
         sequence_output: List[Tensor]  # embeddings + encoder layers?
-        att_output: List[Tensor]  # num ecoder layers
+        att_output: List[Tensor]  # num encoder layers
         pooled_output: Tensor  # [Batch, EmbDim]
         sequence_output, att_output, pooled_output = self.bert(input_ids, token_type_ids, attention_mask)
         tmp = []
@@ -1292,25 +1304,25 @@ class TinyBertForSequenceClassification(BertPreTrainedModel):
 
     def forward(
             self,
-            input_ids: Int[torch.Tensor, "batch sequence"],
-            token_type_ids: Optional[Int[torch.Tensor, "batch sequence"]] = None,
-            attention_mask: Optional[Int[torch.Tensor, "batch sequence"]] = None,
+            input_ids: Int[torch.Tensor, "batch seq"],
+            token_type_ids: Optional[Int[torch.Tensor, "batch seq"]] = None,
+            attention_mask: Optional[Int[torch.Tensor, "batch seq"]] = None,
             labels = None,
             is_student: bool = False
     ) -> tuple[
-        Float[torch.Tensor, "batch num_classes"],
-        list[Float[torch.Tensor, "batch head_size sequence sequence"]],
-        list[Float[torch.Tensor, "batch sequence hidden_size"]]
+            Float[torch.Tensor, "batch class"],
+            list[Float[torch.Tensor, "batch head_size seq seq"]],
+            list[Float[torch.Tensor, "batch seq model_dim"]]
     ]:
-        sequence_output: list[Float[torch.Tensor, "batch sequence hidden_size"]]
-        att_output: list[Float[torch.Tensor, "batch head_size sequence sequence"]]
-        pooled_output: Float[torch.Tensor, "batch hidden_size"]
+        sequence_output: list[Float[torch.Tensor, "batch seq model_dim"]]
+        att_output: list[Float[torch.Tensor, "batch head_size seq seq"]]
+        pooled_output: Float[torch.Tensor, "batch model_dim"]
 
         sequence_output, att_output, pooled_output = self.bert(
             input_ids, token_type_ids, attention_mask, output_all_encoded_layers=True, output_att=True
         )
 
-        logits: Float[torch.Tensor, "batch num_classes"] = self.classifier(torch.relu(pooled_output))
+        logits: Float[torch.Tensor, "batch class"] = self.classifier(torch.relu(pooled_output))
 
         if is_student:
             tmp = []


### PR DESCRIPTION
The inference code in this project supports hybrid inference when different layers of the model run on different compute devices.
Concretely, the inference code supports computing `K`, `Q` and `V` weights of one self-attention head on an external device, while
the rest of the model runs on a CPU in a host system. It can be achieved following these steps:

- Extract self-attention weights (`W_k`, `W_q` and `W_v`) using the procedure outlined in the README file.
- Program or transfer these self-attention weights to an external compute devices.
- Change the `./nl_dpe/dpe.py` implementation. Concretely:
  - Update `_BERT_LAYER_INDEX` and `_ATTENTION_HEAD_INDEX` variables to match the self-attention weights that have been exported. These variables provide brief doc strings.
  - Implement the `call` method in that file. We provide a placeholder implementation that demonstrates one possible implementation.
- Run model inference using CLI described in the README file. The inference code will detect if this functionality is enabled and for which self-attention head. The inference code then will call the `dpe.py::call` function and will use its returned three matrices instead of those computed by the model itself. For implementation details on how the `call` method is called during the inference, see the `BertSelfAttention::forward` method in the  `./transformer/modeling.py` file. The relevant code segment starts with `if dpe.enabled(self.bert_layer_index)` line.